### PR TITLE
Train test validate

### DIFF
--- a/coderdata/__init__.py
+++ b/coderdata/__init__.py
@@ -1,2 +1,3 @@
 from .download.downloader import download_data_by_prefix
 from .load.loader import DatasetLoader, join_datasets
+from .split.splitter import train_test_validate

--- a/coderdata/split/__init__.py
+++ b/coderdata/split/__init__.py
@@ -1,0 +1,1 @@
+from .splitter import train_test_validate

--- a/coderdata/split/splitter.py
+++ b/coderdata/split/splitter.py
@@ -14,7 +14,7 @@ from coderdata.load.loader import DatasetLoader
 def train_test_validate(
         data: DatasetLoader,
         split_type: Literal[
-            'mixed-set', 'drug-blind', 'cancer-blind', 'disjoint'
+            'mixed-set', 'drug-blind', 'cancer-blind'
             ]='mixed-set',
         random_state: (int | RandomState | None)=None,
         ) -> tuple[DatasetLoader, DatasetLoader, DatasetLoader]:
@@ -49,11 +49,6 @@ def train_test_validate(
         - *cancer-blind*: Splits according to cancer association. 
             Equivalent to drug-blind, except cancer types will be unique
             to splits.
-        - *disjoint-set*: Splits according to both drug and cancer
-            association. Makes sure that samples in train, test and
-            validate are fully disjoint according to drug and cancer 
-            association, i.e. both a given drug as well as cancer will 
-            be unique to one of the tree splits.
 
         Defaults to *mixed-set*.
     
@@ -78,7 +73,7 @@ def train_test_validate(
 
     # Type checking split_type
     if split_type not in [
-        'mixed-set', 'drug-blind', 'cancer-blind', 'disjoint'
+        'mixed-set', 'drug-blind', 'cancer-blind'
         ]:
         raise ValueError(
             f"{split_type} not an excepted input for 'split_type'"
@@ -171,8 +166,6 @@ def train_test_validate(
         # sampled indices
         df_test = df_other.iloc[idx1]
         df_val = df_other.iloc[idx2]
-    elif split_type == 'disjoint':
-        raise NotImplementedError('disjoint currently not implemented')
     else:
         raise Exception(
             f"`split_type` contains unexpected value '{split_type}'!"

--- a/coderdata/split/splitter.py
+++ b/coderdata/split/splitter.py
@@ -1,0 +1,185 @@
+
+import pandas as pd
+import sys
+
+from typing import Literal
+
+from numpy.random import RandomState
+from sklearn.model_selection import GroupShuffleSplit
+from coderdata.load.loader import DatasetLoader
+
+def train_test_validate(
+        data: DatasetLoader,
+        split_type: Literal[
+            'mixed-set', 'drug-blind', 'cancer-blind', 'disjoint'
+            ]='mixed-set',
+        random_state: (int | RandomState | None)=None,
+        ) -> tuple[DatasetLoader, DatasetLoader, DatasetLoader]:
+    """
+    Splits a `CoderData` object (see also
+    `coderdata.load.loader.DatasetLoader`) into three subsets for 
+    training, testing and validating machine learning algorithms. The 
+    Size of the splits is fixed to 80:10:10 for train:test:validate. The
+    function allows for additional optional arguments, that define the 
+    type of split that is performed as well as a random seed to enable
+    the creation of reproducable splits.
+
+    Parameters
+    ----------
+    data : DatasetLoader
+        CoderData object containing a full dataset either downloaded
+        from the CoderData repository (see also 
+        `coderdata.download.downloader.download_data_by_prefix`) or
+        built locally via the `build_all` process. The object must first
+        be loaded via `coderdata.load.loader.DatasetLoader`.
+    split_type : Literal['mixed-set', 'drug-blind', 'cancer-blind', \
+                'disjoint'], optional
+        Defines the type of split that should be generated:
+            
+        - *mixed-set*: Splits randomly independent of drug / cancer 
+            association of the samples. Individual drugs or cancer types
+            can appear in all three splits
+        - *drug-blind*: Splits according to drug association. Any sample
+            associated with a drug will be unique to one of the splits.
+            For example samples with association to drug A will only be 
+            present in the train split, but never in test or validate.
+        - *cancer-blind*: Splits according to cancer association. 
+            Equivalent to drug-blind, except cancer types will be unique
+            to splits.
+        - *disjoint-set*: Splits according to both drug and cancer
+            association. Makes sure that samples in train, test and
+            validate are fully disjoint according to drug and cancer 
+            association, i.e. both a given drug as well as cancer will 
+            be unique to one of the tree splits.
+
+        Defaults to *mixed-set*.
+    
+    random_state : int | RandomState | None, optional
+        Defines a seed value for the randomization of the splits. Will
+        get passed to internal functions. Providing the seed will enable
+        reproducability of the generated splits.
+
+        Defaults to None
+    
+    Returns
+    -------
+    Splits : tuple[DataLoader, DataLoader, DataLoader]
+        Three `CoderData` objects, one each for train, test & validate.
+
+    Raises
+    -------
+    ValueError : 
+    If supplied `split_type` is not in the list of accepted values.
+
+    """
+
+    # Type checking split_type
+    if split_type not in [
+        'mixed-set', 'drug-blind', 'cancer-blind', 'disjoint'
+        ]:
+        raise ValueError(
+            f"{split_type} not an excepted input for 'split_type'"
+            )
+
+    df_full = data.experiments.copy()
+
+    if split_type in ['mixed-set', 'drug-blind', 'cancer-blind']:
+        # GroupShuffleSplit is a method/class implemented by 
+        # scikit-learn that enables creating splits that are grouped 
+        # over values of a defined column. Specifically this will 
+        # guarantee that samples/rows with a specific column value will 
+        # only appear in one of the two created splits.
+        #
+        # n defines how often a train/test split is generated not the 
+        # number of splits generated.
+        #
+        # For the first split we define train/"other" (other will be
+        # split into train and validate later) being split 80/20
+        gss = GroupShuffleSplit(
+            n_splits=1,
+            train_size=0.8,
+            test_size=0.2,
+            random_state=random_state
+        )
+
+        if split_type == 'mixed-set':
+            # For the mixed-set we first need to define a combined 
+            # drug and sample id, since there are multiple rows with 
+            # identical sample, drug id pairs but recording differnt 
+            # drug effect strength measures (e.g. ic50 and auc) 
+            df_full['sample_id_drug_id'] = (
+                df_full.improve_sample_id.astype(str)
+                + '-'
+                + df_full.improve_drug_id
+            )
+            # The split is grouped by the new column and genereated
+            # gss.split generates a list of length n with n different 
+            # train/test splits (see above). In our case we only 
+            # generate one split, but we still need the 'next' to access
+            # it. Row ids for items in train (idx2) and other (idx2) are
+            # extracted.
+            idx1, idx2 = next(
+                gss.split(df_full, groups=df_full.sample_id_drug_id)
+                )
+        elif split_type == 'drug_blind':
+            # same as above we just group only over the drug id
+            idx1, idx2 = next(
+                gss.split(df_full, groups=df_full.improve_drug_id)
+                )
+        elif split_type == 'cancer-blind':
+            # same as above we just group only over the sample id
+            idx1, idx2 = next(
+                gss.split(df_full, groups=df_full.improve_sample_id)
+                )
+        else:
+            raise Exception(f"Should be unreachable")
+
+        # generate new DFs containing the subset of items extracted for
+        # train and other
+        df_train = df_full.iloc[idx1]
+        df_other = df_full.iloc[idx2]
+        
+        # generate now Splitter to split other into test and validate
+        gss = GroupShuffleSplit(
+            n_splits=1,
+            train_size=0.5,
+            test_size=0.5,
+            random_state=random_state
+        )
+
+        # follows same logic as previous splitting with the difference
+        # that only "other" is sampled and split
+        if split_type == 'mixed-set':
+            idx1, idx2 = next(
+                gss.split(df_other, groups=df_other.sample_id_drug_id)
+                )
+        elif split_type == 'drug-blind':
+            idx1, idx2 = next(
+                gss.split(df_other, groups=df_other.improve_drug_id)
+                )
+        elif split_type == 'cancer-blind':
+            idx1, idx2 = next(
+                gss.split(df_other, groups=df_other.improve_sample_id)
+                )
+        else:
+            raise Exception(f"Should be unreachable")
+        
+        # extract itmes for test and validate from other based on the 
+        # sampled indices
+        df_test = df_other.iloc[idx1]
+        df_val = df_other.iloc[idx2]
+    elif split_type == 'disjoint':
+        raise NotImplementedError('disjoint currently not implemented')
+    
+    else:
+        raise Exception(
+            f"`split_type` contains unexpected value '{split_type}'!"
+            )
+
+    
+    return (df_train, df_test, df_val)
+
+
+def get_subset(df_full: pd.DataFrame, df_subset: pd.DataFrame):
+    idx = df_subset.index
+    return df_full.drop(idx, axis='index')


### PR DESCRIPTION
# PR for the training / testing and validation set generation scripts.

PR adds coderdata.split.splitter which contains:
- train_test_validate()
- _create_classes()
- _filter()

## train_test_validate()
This is the main (and "public") function of the submodule. The function enables the generation of train/test/validation splits. Returns 3 individual CoderData objects, one each for tain, test and validate. Arguments that can modify how the individual splits are generated are:
- split_type : {'mixed-set', 'drug-blind', 'cancer-blind'} - this should be self explanatory
- ratio : tuple[int, int, int] - for example ratio=(8,1,1) would result in a 80/10/10 split between train/test/validate
- stratify_by : str | None - if None no stratification will happen. If passed string is a drug response metric the stratification will be based on this metric
- random_state - should be self explanatory
- **kwargs - additional keyword arguments that can be passed along to `_create_classes()` and will influence how the classes are cerated.

## _create_classes()
Internal "private" helper function to internally create classes that are needed for the stratification. Arguments (besides the dataset) are:
- metric - same as `split_type` in `train_test_validate` if `split_type != None` 
- num_classes : int - defines the number of classes that should be generated
- quantiles : bool - if set to `True` "bin size" is such that every bin has approximately the same number of datapoints in the reference dataset. If set to `False` then the bin size is chosen to be uniform in the range of the drug response metric values.
- thresh : float - Can only be used if `num_classes == 2` & `quantiles == False`; Can be used to set a threshold for "uneven" bin size.

## _filter()
Internal "private" helper function that aids in creating filtered subsets of the reference CoderData object which only contain data points that pertain to the individual train / test & validate sets.

# Example call:
```python
import coderdata as cd
data = cd.DatasetLoader('beataml')
train, test, validate = cd.train_test_validate(
    data,
    split_type='cancer-blind',
    ratio=[8,1,1],
    stratify_by='fit_auc',
    random_state=42,
    num_classes=5,
    )
```
The call detailed above would generate a training, testing & validation CoderData object, based on the `BeatAML` dataset. The splits are generated such that the individual sets are `cancer-blind`, i.e. cell lines used to test drugs on in `train` are not present in either `test` or `validate` and vice versa. Ratios for the split sizes are 8:1:1 for train/test/validate. The split is done with stratification by using `fit_auc` as a reference. Stratification also is done by internally generating 5 classes (`num_classes=5`) as well as using "quantiles" (does not need to defined in the function call since this is the default behavior - if evenly spaced classes are desired set `quantiles=False`). Finally the seed for the randomization is set to 42 to generate a reproducible split (`random_state=42`).

# What this PR **DOESN'T** do:
Implement a Class function call akin to `dataset.train_test_validate()` that can be directly called based on the loaded CoderData object. 
