### PR TITLE
Allows Documentation Site to be built with Manual Github Action Trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
           - '*'  # Triggers the workflow only on version tags
+  workflow_dispatch:  # Allows manual triggering of the workflow
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
Allows Documentation Site to be built with Manual Github Action Trigger
Previous Behavior - Docs site built when new version tag released.

New Behavior - Docs site built when new version tag released AND when manually clicked on the GitHub Actions site.