### PR TITLE
concatenation fix for bladderpdo exp files

### DIFF
--- a/build/bladderpdo/03_createBladderPDOExperimentFile.py
+++ b/build/bladderpdo/03_createBladderPDOExperimentFile.py
@@ -48,9 +48,9 @@ def get_bladder_pdo_experiments(synObject, samples, drugs):
         final_drugdata['time_unit'] = 'days'
         #print(final_drugdata.head)
         # append to dataframe
-        dose_resp_df = pd.concat([drug_df, final_drugdata])
+        drug_df = pd.concat([drug_df, final_drugdata])
     
-    return dose_resp_df
+    return drug_df
 
 
 if __name__ == "__main__": 

--- a/build/bladderpdo/build_exp.sh
+++ b/build/bladderpdo/build_exp.sh
@@ -6,4 +6,4 @@ trap 'echo "Error on or near line $LINENO while executing: $BASH_COMMAND"; exit 
 echo "Running 04-drug_dosage_and_curves.py with drugfile $2 and curSampleFile $1"
 python3 03_createBladderPDOExperimentFile.py --token $SYNAPSE_AUTH_TOKEN --drugfile $2 --curSampleFile $1 --output /tmp/bladderpdo_doserep.tsv
 
-python3 fit_curve.py --input /tmp/bladderpdo_doserep.tsv --output /tmp/bladderpdo_doserep.tsv
+python3 fit_curve.py --input /tmp/bladderpdo_doserep.tsv --output /tmp/bladderpdo_experiments.tsv


### PR DESCRIPTION
Fixed a concatenation error that resulted in only one drug's inclusion in the experiments file - now all drugs are included.