### PR TITLE
Adding all datasets to mapping scripts.

### DIFF
--- a/build/build_all.py
+++ b/build/build_all.py
@@ -40,7 +40,7 @@ Upload the latest data to Figshare (ensure tokens are set in the local environme
     parser.add_argument('--figshare', action='store_true', help="Upload all local data to Figshare. FIGSHARE_TOKEN must be set in local environment.")
     parser.add_argument('--all',dest='all',default=False,action='store_true', help="Run all data build commands. This includes docker, samples, omics, drugs, exp arguments. This does not run the validate or figshare commands")
     parser.add_argument('--high_mem',dest='high_mem',default=False,action='store_true',help = "If you have 32 or more CPUs, this option is recommended. It will run many code portions in parallel. If you don't have enough memory, this will cause a run failure.")
-    parser.add_argument('--dataset',dest='datasets',default='broad_sanger,hcmi,beataml,cptac,mpnst,mpnstpdx,pancpdo',help='Datasets to process. Defaults to all available.')
+    parser.add_argument('--dataset',dest='datasets',default='broad_sanger,hcmi,beataml,cptac,mpnst,mpnstpdx,pancpdo,bladderpdo',help='Datasets to process. Defaults to all available.')
     parser.add_argument('--version', type=str, required=False, help='Version number for the Figshare upload title (e.g., "0.1.29"). This is required for Figshare upload. This must be a higher version than previously published versions.')
     parser.add_argument('--github-username', type=str, required=False, help='GitHub username for the repository.')
     parser.add_argument('--github-email', type=str, required=False, help='GitHub email for the repository.')

--- a/scripts/map_improve_drug_ids.py
+++ b/scripts/map_improve_drug_ids.py
@@ -369,7 +369,7 @@ so their TSV files are properly rewritten.
                         help='Build date in YYYY-MM-DD. Default=now.')
     parser.add_argument('--version', required=True,
                         help='Build version. Must be unique per build.')
-    parser.add_argument('--datasets', default='gdscv1,broad_sanger,ccle,ctrpv2,fimm,gcsi,gdscv2,nci60,prism,beataml,mpnst,mpnstpdx',
+    parser.add_argument('--datasets', default='gdscv1,ccle,ctrpv2,fimm,gcsi,gdscv2,nci60,prism,beataml,mpnst,mpnstpdx,pancpdo,bladderpdo',
                         help='Comma-separated list of datasets.')
     parser.add_argument('--local_dir', default='data',
                         help='Directory containing TSV files.')

--- a/scripts/map_improve_sample_ids.py
+++ b/scripts/map_improve_sample_ids.py
@@ -412,7 +412,7 @@ update improve_sample_mapping.json, and rewrite files by replacing improve_sampl
                         help='Build date in YYYY-MM-DD. Default=now.')
     parser.add_argument('--version', required=True,
                         help='Build version. Must be unique per build.')
-    parser.add_argument('--datasets', default='ccle,ctrpv2,fimm,gcsi,gdscv1,gdscv2,nci60,prism,hcmi,beataml,cptac,mpnst,mpnstpdx',
+    parser.add_argument('--datasets', default='ccle,ctrpv2,fimm,gcsi,gdscv1,gdscv2,nci60,prism,hcmi,beataml,cptac,mpnst,mpnstpdx,pancpdo,bladderpdo',
                         help='Comma-separated list of datasets, e.g., beataml,ccle')
     parser.add_argument('--local_dir', default='data',
                         help='Directory containing all CSV/TSV files.')


### PR DESCRIPTION
This is a very small change that I'm going to go ahead and merge.  

This just adds the names of the new datasets to build_all.py, map_improve_drug_ids.py, and map_improve_sample_ids.py.

This was missing from the most recent build attempt and should (hopefully) be the last thing needed to ensure that samples are mapped between builds