### PR TITLE
changing canonicalSMILES to SMILES to fix bug

### DIFF
--- a/build/utils/pubchem_retrieval.py
+++ b/build/utils/pubchem_retrieval.py
@@ -86,12 +86,12 @@ def retrieve_drug_info(compound, ignore_chems, isname=True):
 
     if isname:
         urls = {
-            "properties": f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{compound}/property/CanonicalSMILES,InChIKey,MolecularFormula,MolecularWeight/JSON",
+            "properties": f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{compound}/property/SMILES,InChIKey,MolecularFormula,MolecularWeight/JSON",
             "synonyms": f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/name/{compound}/synonyms/JSON"
         }
     else:
         urls = {
-            "properties": f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/CID/{compound}/property/CanonicalSMILES,InChIKey,MolecularFormula,MolecularWeight/JSON",
+            "properties": f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/CID/{compound}/property/SMILES,InChIKey,MolecularFormula,MolecularWeight/JSON",
             "synonyms": f"https://pubchem.ncbi.nlm.nih.gov/rest/pug/compound/CID/{compound}/synonyms/JSON"
         }
 
@@ -131,13 +131,13 @@ def retrieve_drug_info(compound, ignore_chems, isname=True):
             existing_synonyms.add(synonym_lower)
 
         # Check for structure
-        if properties['CanonicalSMILES'] in existing_structures.keys():
+        if properties['SMILES'] in existing_structures.keys():
             print(f'Found structure for {compound}')
-            SMI_assignment = existing_structures[properties['CanonicalSMILES']]
+            SMI_assignment = existing_structures[properties['SMILES']]
         else:
             improve_drug_id += 1
             SMI_assignment = f"SMI_{improve_drug_id}"
-            existing_structures[properties['CanonicalSMILES']] = SMI_assignment
+            existing_structures[properties['SMILES']] = SMI_assignment
         
         #print(new_syns)
         data_for_tsv = [{
@@ -259,7 +259,7 @@ def update_dataframe_and_write_tsv(unique_names, output_filename="drugs.tsv", ig
                         f.write("improve_drug_id\tchem_name\tpubchem_id\tcanSMILES\tInChIKey\tformula\tweight\n")
                     for entry in data:
                         f.write(f"{entry['improve_drug_id']}\t{entry['name']}\t{entry.get('CID', '')}\t"
-                                f"{entry['CanonicalSMILES']}\t{entry['InChIKey']}\t"
+                                f"{entry['SMILES']}\t{entry['InChIKey']}\t"
                                 f"{entry['MolecularFormula']}\t{entry['MolecularWeight']}\n")
 
                 with open(ignore_chems, "a") as ig_f:


### PR DESCRIPTION
Changed pubchem_retrieval.py to use "SMILES" instead of "canonicalSMILES" because that property was removed and was therefore causing a 400 error.  Tested this code by building crcpdo. This is related to issue #415 